### PR TITLE
Enforce upload order

### DIFF
--- a/mod_manager.py
+++ b/mod_manager.py
@@ -23,6 +23,9 @@ SECTION_TO_FOLDER = {
     "Main": "main",
 }
 
+# Desired order for uploading packaged zips
+UPLOAD_ORDER = ["extra", "core", "cosmos", "cosmetic", "main"]
+
 SECTION_ALIASES = {k.lower(): k for k in SECTION_TO_FOLDER}
 
 
@@ -437,11 +440,11 @@ def zip_folders(output_dir: str = "packages") -> List[str]:
 def upload_packages(token: str, packages_dir: str = "packages") -> None:
     meta_url = "https://thunderstore.io/api/experimental/submission/submit/"
 
-    for name in os.listdir(packages_dir):
-        if not name.lower().endswith(".zip"):
-            continue
-
+    for folder in UPLOAD_ORDER:
+        name = f"{folder}.zip"
         path = os.path.join(packages_dir, name)
+        if not os.path.isfile(path):
+            continue
 
         with zipfile.ZipFile(path, "r") as zf:
             with zf.open("manifest.json") as mf:


### PR DESCRIPTION
## Summary
- add UPLOAD_ORDER constant to specify publishing order
- update `upload_packages` to follow this order

## Testing
- `python -m py_compile mod_manager.py`

------
https://chatgpt.com/codex/tasks/task_e_685ec9bd9dc083339d86460408914f31